### PR TITLE
chore: add export flag on types:generate command for vue and react

### DIFF
--- a/src/utils/scaffold.ts
+++ b/src/utils/scaffold.ts
@@ -561,14 +561,16 @@ export class Scaffold {
 
 		const packageObject: any = JSON.parse(readFileSync(packageName).toString());
 
+		const ex = ['react', 'vue'].includes(this.command.onboarding.stack?.toLowerCase() ?? '') ? ' --export' : '';
+
 		if (this.command.onboarding.manager !== 'pnpm') {
 			packageObject.development['commands'] = [
-				"node craftsman types:generate"
+				`node craftsman types:generate${ex}`
 			]
 		} else {
 			packageObject.development = {
 				commands: [
-					"node craftsman types:generate"
+					`node craftsman types:generate${ex}`
 				]
 			}
 		}


### PR DESCRIPTION
## Update
* Added `--export` to `types:generate` command for vue and react